### PR TITLE
Use suspense query

### DIFF
--- a/base-blog-em/src/PostDetail.jsx
+++ b/base-blog-em/src/PostDetail.jsx
@@ -6,6 +6,7 @@ export function PostDetail({ post }) {
   const { data } = useSuspenseQuery({
     queryKey: ["detail", post.id],
     queryFn: () => fetchComments(post.id),
+    staleTime: 1000 * 60 * 5,
   });
 
   const deleteMutation = useMutation({

--- a/base-blog-em/src/PostDetail.jsx
+++ b/base-blog-em/src/PostDetail.jsx
@@ -1,9 +1,9 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { deletePost, fetchComments, updatePost } from "./api";
 import "./PostDetail.css";
 
 export function PostDetail({ post }) {
-  const { data, isLoading } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ["detail", post.id],
     queryFn: () => fetchComments(post.id),
   });
@@ -29,10 +29,6 @@ export function PostDetail({ post }) {
   if (isSuccess) {
     console.log("[submittedAt]:", submittedAt);
     console.log("mutation success", mutateData);
-  }
-
-  if (isLoading) {
-    return <>Loading...</>;
   }
 
   if (!data) {

--- a/base-blog-em/src/Posts.jsx
+++ b/base-blog-em/src/Posts.jsx
@@ -34,7 +34,7 @@ export function Posts() {
         queryClient.prefetchQuery({
           queryKey: ["detail", post.id],
           queryFn: () => fetchComments(post.id),
-          staleTime: 5000,
+          staleTime: 1000 * 60 * 60,
         });
       });
     }


### PR DESCRIPTION
**5분으로 조정**
2. 5분이내 컴포넌트가 다시 마운트 되어 useSuspenseQuery 실행되어도 네트워크 탭에 API 요청 생기지 X
3. 아직 fresh한 상태이므로 trigger 포인트 생겨서 네트워크 요청하지 않는다
4. 쿼리 캐시에 있는 값을 사용한다.
5.  부모의 prefetch는 페이지가 변할때 실행되므로, 포스트를 클릭할때는 실행되지 X
6. 따라서 포스트 클릭시는 useSuspenseQuery만 staleTime의해 영향을 받는다


> 자식 컴포넌트가 사용 중인 useSuepsense 감지
> useQuery처럼 isLoading이 불필요
> 해당 데이터를 prefetch 해왔다면 fallback은 안 뜸
